### PR TITLE
fix double read as float: issue 18

### DIFF
--- a/src/databricks/sqlalchemy/_parse.py
+++ b/src/databricks/sqlalchemy/_parse.py
@@ -309,7 +309,7 @@ GET_COLUMNS_TYPE_MAP = {
     "int": sqlalchemy.types.Integer,
     "bigint": sqlalchemy.types.BigInteger,
     "float": sqlalchemy.types.Float,
-    "double": sqlalchemy.types.Float,
+    "double": sqlalchemy.types.Double,
     "string": sqlalchemy.types.String,
     "varchar": sqlalchemy.types.String,
     "char": sqlalchemy.types.String,


### PR DESCRIPTION
Context: https://github.com/databricks/databricks-sqlalchemy/issues/18

I successfully tested this with the local unit tests:
```shell
poetry run python3 -m pytest tests/test_local/*.py
```

I also was able to prove, in the context of our alembic setup, that this prevented the erroneous messages and alter column commands in the migration script.

I do not have a Databricks workspace available with which I'm comfortable running the `e2e` tests.