### PR TITLE
fix column ddl bug

### DIFF
--- a/src/databricks/sqlalchemy/_ddl.py
+++ b/src/databricks/sqlalchemy/_ddl.py
@@ -1,6 +1,7 @@
-import re
-from sqlalchemy.sql import compiler, sqltypes
 import logging
+import re
+
+from sqlalchemy.sql import compiler, sqltypes
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +69,15 @@ class DatabricksDDLCompiler(compiler.DDLCompiler):
         See comments in test_suite.py. We may implement implicit IDENTITY using this
         feature in the future, similar to the Microsoft SQL Server dialect.
         """
-        if column is column.table._autoincrement_column or column.autoincrement is True:
+        is_autoincrement = bool(column.autoincrement)
+        if (
+            column.table is not None  # column.table can be None
+            and not is_autoincrement
+        ):
+            if column is column.table._autoincrement_column:
+                is_autoincrement = True
+
+        if is_autoincrement:
             logger.warning(
                 "Databricks dialect ignores SQLAlchemy's autoincrement semantics. Use explicit Identity() instead."
             )


### PR DESCRIPTION
`Column.table` can be `None`, and when that happens it results in:

```
AttributeError: 'NoneType' object has no attribute '_autoincrement_column'
```

We use SQLAlchemy to compose dialect-correct DDL statements like:

```
import sqlalchemy as sa
from sqlalchemy.sql import ddl

create_column_clause = ddl.CreateColumn(
    sa.Column(
       column_name,
        column_type,
    ),
)
compiled = create_column_clause.compile(self._engine).string
return sa.DDL(
    "ALTER TABLE %(table_name)s ADD COLUMN %(create_column_clause)s",
    {
        "table_name": table_name,
        "create_column_clause": compiled,
    },
)
```

This is why `Column.table` is `None`.