### PR TITLE
Turn on native booleans

### DIFF
--- a/src/databricks/sqlalchemy/dialect/__init__.py
+++ b/src/databricks/sqlalchemy/dialect/__init__.py
@@ -82,6 +82,7 @@ class DatabricksDialect(default.DefaultDialect):
     supports_native_decimal: bool = True
     supports_sane_rowcount: bool = False
     non_native_boolean_check_constraint: bool = False
+    supports_native_boolean: bool = True
 
     @classmethod
     def dbapi(cls):


### PR DESCRIPTION
While using the library with Superset 4.1, I realized "is true" filter [used in Superset charts](https://github.com/apache/superset/blob/4.1/superset/models/helpers.py#L1846-L1849) doesn't work expected: it produces expressions like `my_bool = 1` which Databricks SQL doesn't support. Enabling `supports_native_boolean` setting makes superset produce the correct query.