### PR TITLE
[PECOBLR-666]Added support for Variant datatype in SQLAlchemy

### DIFF
--- a/src/databricks/sqlalchemy/__init__.py
+++ b/src/databricks/sqlalchemy/__init__.py
@@ -5,6 +5,7 @@ from databricks.sqlalchemy._types import (
     TIMESTAMP_NTZ,
     DatabricksArray,
     DatabricksMap,
+    DatabricksVariant,
 )
 
-__all__ = ["TINYINT", "TIMESTAMP", "TIMESTAMP_NTZ", "DatabricksArray", "DatabricksMap"]
+__all__ = ["TINYINT", "TIMESTAMP", "TIMESTAMP_NTZ", "DatabricksArray", "DatabricksMap", "DatabricksVariant"]

--- a/src/databricks/sqlalchemy/__init__.py
+++ b/src/databricks/sqlalchemy/__init__.py
@@ -8,4 +8,11 @@ from databricks.sqlalchemy._types import (
     DatabricksVariant,
 )
 
-__all__ = ["TINYINT", "TIMESTAMP", "TIMESTAMP_NTZ", "DatabricksArray", "DatabricksMap", "DatabricksVariant"]
+__all__ = [
+    "TINYINT",
+    "TIMESTAMP",
+    "TIMESTAMP_NTZ",
+    "DatabricksArray",
+    "DatabricksMap",
+    "DatabricksVariant",
+]

--- a/src/databricks/sqlalchemy/_parse.py
+++ b/src/databricks/sqlalchemy/_parse.py
@@ -318,6 +318,7 @@ GET_COLUMNS_TYPE_MAP = {
     "map": sqlalchemy.types.String,
     "struct": sqlalchemy.types.String,
     "uniontype": sqlalchemy.types.String,
+    "variant": type_overrides.DatabricksVariant,
     "decimal": sqlalchemy.types.Numeric,
     "timestamp": type_overrides.TIMESTAMP,
     "timestamp_ntz": type_overrides.TIMESTAMP_NTZ,

--- a/src/databricks/sqlalchemy/_types.py
+++ b/src/databricks/sqlalchemy/_types.py
@@ -446,7 +446,7 @@ class DatabricksVariant(UserDefinedType):
             except (TypeError, ValueError) as e:
                 raise ValueError(f"Cannot serialize value {value} to JSON: {e}")
             
-        return f"PARSE_JSON('{process}')"
+        return process
 
 @compiles(DatabricksVariant, "databricks")
 def compile_variant(type_, compiler, **kw):

--- a/src/databricks/sqlalchemy/_types.py
+++ b/src/databricks/sqlalchemy/_types.py
@@ -9,6 +9,7 @@ from sqlalchemy.types import TypeDecorator, UserDefinedType
 
 from databricks.sql.utils import ParamEscaper
 
+from sqlalchemy.sql import expression
 
 def process_literal_param_hack(value: Any):
     """This method is supposed to accept a Python type and return a string representation of that type.
@@ -397,3 +398,47 @@ def compile_databricks_map(type_, compiler, **kw):
     key_type = compiler.process(type_.key_type, **kw)
     value_type = compiler.process(type_.value_type, **kw)
     return f"MAP<{key_type},{value_type}>"
+
+class DatabricksVariant(UserDefinedType):
+    """
+    A custom variant type for storing semi-structured data including STRUCT, ARRAY, MAP, and scalar types.
+    Note: VARIANT MAP types can only have STRING keys.
+    
+    Examples:
+        DatabricksVariant()  -> VARIANT
+        
+    Usage:
+        Column('data', DatabricksVariant())
+    """
+    cache_ok = True
+
+    def __init__(self):
+        self.pe = ParamEscaper()
+
+    def bind_processor(self, dialect):
+        """Process values before sending to database.
+        """
+
+        def process(value):
+            return value
+
+        return process
+
+    def bind_expression(self, bindvalue):
+        """Wrap with PARSE_JSON() in SQL"""
+        return expression.func.PARSE_JSON(bindvalue)
+
+    def literal_processor(self, dialect):
+        """Process literal values for SQL generation.      
+        For VARIANT columns, use PARSE_JSON() to properly insert data.
+        """
+        def process(value):
+            if value is None:
+                return "NULL"
+            return self.pe.escape_string(value)
+            
+        return f"PARSE_JSON('{process}')"
+
+@compiles(DatabricksVariant, "databricks")
+def compile_variant(type_, compiler, **kw):
+    return "VARIANT"

--- a/tests/test_local/test_ddl.py
+++ b/tests/test_local/test_ddl.py
@@ -7,7 +7,7 @@ from sqlalchemy.schema import (
     SetColumnComment,
     SetTableComment,
 )
-from databricks.sqlalchemy import DatabricksArray, DatabricksMap
+from databricks.sqlalchemy import DatabricksArray, DatabricksMap, DatabricksVariant
 
 
 class DDLTestBase:
@@ -103,7 +103,8 @@ class TestTableComplexTypeDDL(DDLTestBase):
         metadata = MetaData()
         col1 = Column("array_array_string", DatabricksArray(DatabricksArray(String)))
         col2 = Column("map_string_string", DatabricksMap(String, String))
-        table = Table("complex_type", metadata, col1, col2)
+        col3 = Column("variant_col", DatabricksVariant())
+        table = Table("complex_type", metadata, col1, col2, col3)
         return metadata
 
     def test_create_table_with_complex_type(self, metadata):
@@ -112,3 +113,4 @@ class TestTableComplexTypeDDL(DDLTestBase):
 
         assert "array_array_string ARRAY<ARRAY<STRING>>" in output
         assert "map_string_string MAP<STRING,STRING>" in output
+        assert "variant_col VARIANT" in output

--- a/tests/test_local/test_types.py
+++ b/tests/test_local/test_types.py
@@ -4,7 +4,7 @@ import pytest
 import sqlalchemy
 
 from databricks.sqlalchemy.base import DatabricksDialect
-from databricks.sqlalchemy._types import TINYINT, TIMESTAMP, TIMESTAMP_NTZ
+from databricks.sqlalchemy._types import TINYINT, TIMESTAMP, TIMESTAMP_NTZ, DatabricksVariant
 
 
 class DatabricksDataType(enum.Enum):
@@ -28,6 +28,7 @@ class DatabricksDataType(enum.Enum):
     ARRAY = enum.auto()
     MAP = enum.auto()
     STRUCT = enum.auto()
+    VARIANT = enum.auto()
 
 
 # Defines the way that SQLAlchemy CamelCase types are compiled into Databricks SQL types.
@@ -131,6 +132,7 @@ uppercase_type_map = {
     TINYINT: DatabricksDataType.TINYINT,
     TIMESTAMP: DatabricksDataType.TIMESTAMP,
     TIMESTAMP_NTZ: DatabricksDataType.TIMESTAMP_NTZ,
+    DatabricksVariant: DatabricksDataType.VARIANT,
 }
 
 


### PR DESCRIPTION
## Description
Added support for Variant type. Users can now insert and read from the Variant type columns.

Pandas being one of the most important use cases for SQLAlchemy, additional testing has been added to test for Pandas specific use cases. User needs to explicitly provide the `dtype` parameter for `pandas.to_sql()` that'll define which columns are of variant type.

## Testing
Added unit and E2E tests for `DatabricksVariant` type
- Table creation (DDL)
- Data insertion and retrieval via ORM and pandas
- Data comparison and round-trip correctness

## Related tickets and documents
[PECOBLR-666](https://databricks.atlassian.net/browse/PECOBLR-666)


[PECOBLR-666]: https://databricks.atlassian.net/browse/PECOBLR-666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ