### PR TITLE
 Rename _user_agent_entry to user_agent_entry

### DIFF
--- a/sqlalchemy_example.py
+++ b/sqlalchemy_example.py
@@ -53,7 +53,7 @@ schema = os.getenv("DATABRICKS_SCHEMA")
 # See src/databricks/sql/thrift_backend.py for complete list
 extra_connect_args = {
 	"_tls_verify_hostname": True,
-	"_user_agent_entry": "PySQL Example Script",
+	"user_agent_entry": "PySQL Example Script",
 }
 
 

--- a/src/databricks/sqlalchemy/base.py
+++ b/src/databricks/sqlalchemy/base.py
@@ -409,21 +409,12 @@ def receive_do_connect(dialect, conn_rec, cargs, cparams):
     if not dialect.name == "databricks":
         return
 
-    ua = cparams.get("_user_agent_entry", "")
+    ua = cparams.get("user_agent_entry", "sqlalchemy")
 
-    def add_sqla_tag_if_not_present(val: str):
-        if not val:
-            output = "sqlalchemy"
+    if "sqlalchemy" not in ua:
+        ua = f"sqlalchemy + {ua}"
 
-        if val and "sqlalchemy" in val:
-            output = val
-
-        else:
-            output = f"sqlalchemy + {val}"
-
-        return output
-
-    cparams["_user_agent_entry"] = add_sqla_tag_if_not_present(ua)
+    cparams["user_agent_entry"] = ua
 
     if sqlalchemy.__version__.startswith("1.3"):
         # SQLAlchemy 1.3.x fails to parse the http_path, catalog, and schema from our connection string

--- a/tests/test_local/e2e/test_basic.py
+++ b/tests/test_local/e2e/test_basic.py
@@ -55,7 +55,7 @@ def version_agnostic_connect_arguments(connection_details) -> Tuple[str, dict]:
     CATALOG = connection_details["catalog"]
     SCHEMA = connection_details["schema"]
 
-    ua_connect_args = {"_user_agent_entry": USER_AGENT_TOKEN}
+    ua_connect_args = {"user_agent_entry": USER_AGENT_TOKEN}
 
     if sqlalchemy_1_3():
         conn_string = f"databricks://token:{ACCESS_TOKEN}@{HOST}"
@@ -510,7 +510,7 @@ class TestCommentReflection:
         SCHEMA = connection_details["schema"]
 
         connection_string = f"databricks://token:{ACCESS_TOKEN}@{HOST}?http_path={HTTP_PATH}&catalog={CATALOG}&schema={SCHEMA}"
-        connect_args = {"_user_agent_entry": USER_AGENT_TOKEN}
+        connect_args = {"user_agent_entry": USER_AGENT_TOKEN}
 
         engine = create_engine(connection_string, connect_args=connect_args)
         return engine

--- a/tests/test_local/e2e/test_setup.py
+++ b/tests/test_local/e2e/test_setup.py
@@ -16,7 +16,7 @@ class TestSetup:
         CATALOG = self.arguments["catalog"]
         SCHEMA = self.arguments["schema"]
 
-        connect_args = {"_user_agent_entry": "SQLAlchemy e2e Tests"}
+        connect_args = {"user_agent_entry": "SQLAlchemy e2e Tests"}
 
         conn_string = f"databricks://token:{ACCESS_TOKEN}@{HOST}?http_path={HTTP_PATH}&catalog={CATALOG}&schema={SCHEMA}"
         return create_engine(conn_string, connect_args=connect_args)


### PR DESCRIPTION
Update to reflect the fact that _user_agent_entry is deprecated in databricks-sql-python and will be repaced by user_agent_entry.

Closes #36