### PR TITLE
Version bump to 2.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+# 2.0.9 (2026-02-20)
+
+- Feature: Added `pool_pre_ping` support via `do_ping()` override to detect and recycle dead connections (databricks/databricks-sqlalchemy#54 by @msrathore-db)
+- Fix: Pinned poetry version in CI workflows to fix build failures (databricks/databricks-sqlalchemy#54 by @msrathore-db)
+
 # 2.0.8 (2025-09-08)
 
 - Feature: Added support for variant datatype (databricks/databricks-sqlalchemy#42 by @msrathore-db)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databricks-sqlalchemy"
-version = "2.0.8"
+version = "2.0.9"
 description = "Databricks SQLAlchemy plugin for Python"
 authors = ["Databricks <databricks-sql-connector-maintainers@databricks.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump version from 2.0.8 to 2.0.9
- Update CHANGELOG.md with 2.0.9 release notes

## Changes in this release

- Feature: Added `pool_pre_ping` support via `do_ping()` override to detect and recycle dead connections (#54)
- Fix: Pinned poetry version in CI workflows to fix build failures (#54)