### PR TITLE
Harden CI/CD workflows: pin actions to SHA, restrict triggers, scope permissions

### DIFF
--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -7,6 +7,10 @@ on:
         branches:
             - main
     workflow_dispatch:
+
+permissions:
+    contents: read
+
 jobs:
     check-linting:
         runs-on: ubuntu-latest
@@ -18,17 +22,17 @@ jobs:
             #       check-out repo and set-up python
             #----------------------------------------------
             - name: Check out repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
             - name: Set up python ${{ matrix.python-version }}
               id: setup-python
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
               with:
                   python-version: ${{ matrix.python-version }}
             #----------------------------------------------
             #  -----  install & configure poetry  -----
             #----------------------------------------------
             - name: Install Poetry
-              uses: snok/install-poetry@v1
+              uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
               with:
                   version: "2.2.1"
                   virtualenvs-create: true
@@ -40,7 +44,7 @@ jobs:
             #----------------------------------------------
             - name: Load cached venv
               id: cached-poetry-dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
               with:
                   path: .venv
                   key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
@@ -71,17 +75,17 @@ jobs:
             #       check-out repo and set-up python
             #----------------------------------------------
             - name: Check out repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
             - name: Set up python ${{ matrix.python-version }}
               id: setup-python
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
               with:
                   python-version: ${{ matrix.python-version }}
             #----------------------------------------------
             #  -----  install & configure poetry  -----
             #----------------------------------------------
             - name: Install Poetry
-              uses: snok/install-poetry@v1
+              uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
               with:
                   version: "2.2.1"
                   virtualenvs-create: true
@@ -93,7 +97,7 @@ jobs:
             #----------------------------------------------
             - name: Load cached venv
               id: cached-poetry-dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
               with:
                   path: .venv
                   key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -2,15 +2,19 @@ name: DCO Check
 
 on: [pull_request]
 
+permissions:
+    contents: read
+    pull-requests: write
+
 jobs:
     check:
         runs-on: ubuntu-latest
         steps:
             - name: Check for DCO
               id: dco-check
-              uses: tisonkun/actions-dco@v1.1
+              uses: tisonkun/actions-dco@6d1f8a197db1b04df1769707b46b9366b1eca902 # v1.1
             - name: Comment about DCO status
-              uses: actions/github-script@v6
+              uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325 # v6
               if: ${{ failure() }}
               with:
                   script: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,9 +1,14 @@
 name: Integration Tests
 on:
     push:
+        branches:
+            - main
         paths-ignore:
             - "**.MD"
             - "**.md"
+
+permissions:
+    contents: read
 
 jobs:
     run-e2e-tests:
@@ -21,17 +26,17 @@ jobs:
             #       check-out repo and set-up python
             #----------------------------------------------
             - name: Check out repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
             - name: Set up python
               id: setup-python
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
               with:
                   python-version: "3.10"
             #----------------------------------------------
             #  -----  install & configure poetry  -----
             #----------------------------------------------
             - name: Install Poetry
-              uses: snok/install-poetry@v1
+              uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
               with:
                   version: "2.2.1"
                   virtualenvs-create: true
@@ -43,7 +48,7 @@ jobs:
             #----------------------------------------------
             - name: Load cached venv
               id: cached-poetry-dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
               with:
                   path: .venv
                   key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -1,5 +1,12 @@
 name: Publish to PyPI [Test]
-on: [push]
+on:
+    push:
+        branches:
+            - main
+
+permissions:
+    contents: read
+
 jobs:
     test-pypi:
         name: Create patch version number and push to test-pypi
@@ -9,17 +16,17 @@ jobs:
             #       check-out repo and set-up python
             #----------------------------------------------
             - name: Check out repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
             - name: Set up python
               id: setup-python
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
               with:
                   python-version: 3.9
             #----------------------------------------------
             #  -----  install & configure poetry  -----
             #----------------------------------------------
             - name: Install Poetry
-              uses: snok/install-poetry@v1
+              uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
               with:
                   version: "2.2.1"
                   virtualenvs-create: true
@@ -30,7 +37,7 @@ jobs:
             #----------------------------------------------
             - name: Load cached venv
               id: cached-poetry-dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
               with:
                   path: .venv
                   key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
@@ -44,7 +51,7 @@ jobs:
             # Get the current version and increment it (test-pypi requires a unique version number)
             #----------------------------------------------
             - name: Get next version
-              uses: reecetech/version-increment@2022.2.4
+              uses: reecetech/version-increment@ddbbe72b7f76a996076fabfdce21a16384e8644a # 2022.2.4
               id: version
               with:
                   scheme: semver
@@ -56,7 +63,7 @@ jobs:
               run: poetry version ${{ steps.version.outputs.major-version }}.${{ steps.version.outputs.minor-version }}.dev$(date +%s)
 
             - name: Build and publish to pypi
-              uses: JRubics/poetry-publish@v1.10
+              uses: JRubics/poetry-publish@969e8c47dd31083377ab78c536425bbc1b9698f0 # v1.10
               with:
                   pypi_token: ${{ secrets.SQLALCHEMY_TEST_PYPI_TOKEN }}
                   repository_name: "testpypi"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,10 @@ name: Publish to PyPI [Production]
 on:
     release:
         types: [published]
+
+permissions:
+    contents: read
+
 jobs:
     publish:
         name: Publish
@@ -12,17 +16,17 @@ jobs:
             #       check-out repo and set-up python
             #----------------------------------------------
             - name: Check out repository
-              uses: actions/checkout@v2
+              uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
             - name: Set up python
               id: setup-python
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
               with:
                   python-version: 3.9
             #----------------------------------------------
             #  -----  install & configure poetry  -----
             #----------------------------------------------
             - name: Install Poetry
-              uses: snok/install-poetry@v1
+              uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
               with:
                   version: "2.2.1"
                   virtualenvs-create: true
@@ -33,7 +37,7 @@ jobs:
             #----------------------------------------------
             - name: Load cached venv
               id: cached-poetry-dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
               with:
                   path: .venv
                   key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ github.event.repository.name }}-${{ hashFiles('**/poetry.lock') }}
@@ -47,7 +51,7 @@ jobs:
             # Here we use version-increment to fetch the latest tagged version (we won't increment it though)
             #------------------------------------------------------------------------------------------------
             - name: Get next version
-              uses: reecetech/version-increment@2022.2.4
+              uses: reecetech/version-increment@ddbbe72b7f76a996076fabfdce21a16384e8644a # 2022.2.4
               id: version
               with:
                   scheme: semver
@@ -61,6 +65,6 @@ jobs:
             # Attempt push to test-pypi
             #----------------------------------------------
             - name: Build and publish to pypi
-              uses: JRubics/poetry-publish@v1.10
+              uses: JRubics/poetry-publish@969e8c47dd31083377ab78c536425bbc1b9698f0 # v1.10
               with:
                   pypi_token: ${{ secrets.SQLALCHEMY_PROD_PYPI_TOKEN }}


### PR DESCRIPTION
## Summary

Remediates critical and high-severity findings from a supply chain security analysis of all GitHub Actions workflows. This PR hardens CI/CD before re-enabling workflows.

### Changes

- **Pin all 22 GitHub Action references to full commit SHAs** — eliminates tag mutation / upstream compromise attack vector (e.g., `actions/checkout@v2` → `actions/checkout@ee0669bd...  # v2`)
- **Restrict `publish-test.yml` trigger** — changed from `on: [push]` (all branches) to `on: push: branches: [main]` to prevent unauthorized Test PyPI publishing
- **Restrict `integration.yml` trigger** — added `branches: [main]` to prevent Databricks secrets (host, token, catalog, schema, service principal) from being exposed on arbitrary branch pushes
- **Add explicit `permissions:` blocks to all 5 workflows** — enforces least-privilege `GITHUB_TOKEN` scoping (`contents: read` everywhere; `pull-requests: write` only on `dco-check.yml` which needs to post PR comments)

### Findings Addressed

| # | Finding | Severity | Fix |
|---|---------|----------|-----|
| 1 | 22/22 action references used mutable tags — zero SHA pins | **HIGH** | All pinned to full commit SHA |
| 2 | `publish-test.yml` triggered on every push to any branch | **HIGH** | Restricted to `main` only |
| 3 | `integration.yml` triggered on all pushes, exposing 6 Databricks secrets | **HIGH** | Restricted to `main` only |
| 4 | No workflow declared `permissions:` — default token may have write access | **MEDIUM** | Least-privilege permissions added |

### Pinned SHAs

| Action | Tag | SHA |
|--------|-----|-----|
| `actions/checkout` | v2 | `ee0669bd1cc54295c223e0bb666b733df41de1c5` |
| `actions/checkout` | v3 | `f43a0e5ff2bd294095638e18286ca9a3d1956744` |
| `actions/setup-python` | v2 | `e9aba2c848f5ebd159c070c61ea2c4e2b122355e` |
| `actions/setup-python` | v4 | `7f4fc3e22c37d6ff65e88745f38bd3157c663f7c` |
| `actions/cache` | v4 | `0057852bfaa89a56745cba8c7296529d2fc39830` |
| `actions/github-script` | v6 | `00f12e3e20659f42342b1c0226afda7f7c042325` |
| `snok/install-poetry` | v1 | `76e04a911780d5b312d89783f7b1cd627778900a` |
| `tisonkun/actions-dco` | v1.1 | `6d1f8a197db1b04df1769707b46b9366b1eca902` |
| `reecetech/version-increment` | 2022.2.4 | `ddbbe72b7f76a996076fabfdce21a16384e8644a` |
| `JRubics/poetry-publish` | v1.10 | `969e8c47dd31083377ab78c536425bbc1b9698f0` |

### Attack Paths Mitigated

1. **Upstream action compromise via tag mutation** — attacker force-pushes a tag on any third-party action → compromised code runs with access to PyPI tokens and Databricks credentials. *Mitigated by SHA pinning.*
2. **Test PyPI poisoning via merged PR** — any merged PR automatically publishes to Test PyPI with no branch restriction. *Mitigated by restricting trigger to `main`.*
3. **Databricks secret exfiltration** — merged code on any branch triggers integration tests with 6 Databricks secrets. *Mitigated by restricting trigger to `main`.*

### Future Recommendations (not in this PR)

- Replace `JRubics/poetry-publish` with official `pypa/gh-action-pypi-publish`
- Migrate to PyPI OIDC trusted publishing (eliminate long-lived tokens)
- Add `.github/dependabot.yml` for automated SHA pin updates
- Add CODEOWNERS rule for `.github/workflows/`

## Test plan

- [ ] Verify all 5 workflow YAML files parse correctly (no syntax errors)
- [ ] Verify `publish-test.yml` only triggers on pushes to `main`
- [ ] Verify `integration.yml` only triggers on pushes to `main`
- [ ] Verify every `uses:` line across all workflows contains a 40-char SHA
- [ ] Verify `dco-check.yml` has `pull-requests: write` permission (needed for PR comments)
- [ ] Spot-check 2-3 SHAs against GitHub API to confirm they match the intended tags

This pull request was AI-assisted by Isaac.