### PR TITLE
Migrate CI workflows to protected runner group

### DIFF
--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -13,7 +13,9 @@ permissions:
 
 jobs:
     check-linting:
-        runs-on: ubuntu-latest
+        runs-on:
+            group: databricks-protected-runner-group
+            labels: linux-ubuntu-latest
         strategy:
             matrix:
                 python-version: [3.9, "3.10", "3.11", "3.12"]
@@ -66,7 +68,9 @@ jobs:
               run: poetry run black --check src
 
     check-types:
-        runs-on: ubuntu-latest
+        runs-on:
+            group: databricks-protected-runner-group
+            labels: linux-ubuntu-latest
         strategy:
             matrix:
                 python-version: [3.9, "3.10", "3.11", "3.12"]

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -8,7 +8,9 @@ permissions:
 
 jobs:
     check:
-        runs-on: ubuntu-latest
+        runs-on:
+            group: databricks-protected-runner-group
+            labels: linux-ubuntu-latest
         steps:
             - name: Check for DCO
               id: dco-check

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,9 @@ permissions:
 
 jobs:
     run-e2e-tests:
-        runs-on: ubuntu-latest
+        runs-on:
+            group: databricks-protected-runner-group
+            labels: linux-ubuntu-latest
         environment: azure-prod
         env:
             DATABRICKS_SERVER_HOSTNAME: ${{ secrets.DATABRICKS_HOST }}


### PR DESCRIPTION
## Summary
- Replace `ubuntu-latest` GitHub-hosted runners with `databricks-protected-runner-group` across all CI workflow jobs (`code-quality-checks.yml`, `dco-check.yml`, `integration.yml`)
- Improves CI security posture by running all jobs on organization-managed protected runners instead of public GitHub-hosted runners

## Test plan
- [ ] Verify `code-quality-checks` workflow triggers and runs on the protected runner group
- [ ] Verify `dco-check` workflow triggers and runs on the protected runner group
- [ ] Verify `integration` workflow triggers and runs on the protected runner group

This pull request was AI-assisted by Isaac.