### PR TITLE
Bump version to 2.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Fix: Quote bind parameter names with backticks so column names containing characters outside `[A-Za-z0-9_]`, including hyphens, bind correctly (databricks/databricks-sqlalchemy#60 by @msrathore-db)
 - Fix: Bind UUID values in canonical hyphenated form for `Column(Uuid)` and UUID comparisons (databricks/databricks-sqlalchemy#63 by @sreekanth-db)
+- Maintenance: Harden GitHub Actions workflows by pinning actions to SHAs, restricting sensitive triggers, and scoping token permissions (databricks/databricks-sqlalchemy#56 by @jprakash-db)
+- Maintenance: Remove GitHub Actions PyPI publish workflows; publish this release through the current maintainer release process (databricks/databricks-sqlalchemy#57 by @jprakash-db)
+- Maintenance: Move CI to Databricks protected runners with JFrog OIDC and shared Poetry/JFrog setup (databricks/databricks-sqlalchemy#59 by @vikrantpuppala)
 
 # 2.0.9 (2026-02-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+# 2.0.10 (2026-05-26)
+
+- Fix: Quote bind parameter names with backticks so column names containing characters outside `[A-Za-z0-9_]`, including hyphens, bind correctly (databricks/databricks-sqlalchemy#60 by @msrathore-db)
+- Fix: Bind UUID values in canonical hyphenated form for `Column(Uuid)` and UUID comparisons (databricks/databricks-sqlalchemy#63 by @sreekanth-db)
+
 # 2.0.9 (2026-02-20)
 
 - Feature: Added `pool_pre_ping` support via `do_ping()` override to detect and recycle dead connections (databricks/databricks-sqlalchemy#54 by @msrathore-db)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "databricks-sqlalchemy"
-version = "2.0.9"
+version = "2.0.10"
 description = "Databricks SQLAlchemy plugin for Python"
 authors = ["Databricks <databricks-sql-connector-maintainers@databricks.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Motivation

The latest published release is 2.0.9, but main now includes several merged changes that are not in a PyPI patch release. Preparing a 2.0.10 patch release gives users a clear version that includes the SQLAlchemy behavior fixes, while also documenting the CI and release-infrastructure changes that landed after 2.0.9.

## Changes

This bumps the package version in pyproject.toml from 2.0.9 to 2.0.10 and adds 2.0.10 changelog entries for every merged PR on main since v2.0.9:

- #56: hardened GitHub Actions workflows by pinning actions, restricting sensitive triggers, and scoping permissions
- #57: removed the GitHub Actions PyPI publish workflows
- #59: moved CI to Databricks protected runners with JFrog OIDC and shared Poetry/JFrog setup
- #60: fixed bind parameter rendering for column names with non-identifier characters, including hyphens
- #63: fixed UUID binding to use canonical hyphenated values

## Decisions

This PR keeps the scope to release metadata only. It does not restore the removed publish workflows from #57; after merge, maintainers should use the current publishing process to publish the 2.0.10 artifact.